### PR TITLE
Handle absolute includes with basedir option

### DIFF
--- a/test/fixtures/absolute_include.pug
+++ b/test/fixtures/absolute_include.pug
@@ -1,0 +1,3 @@
+extends extends/extends.pug
+block body
+  include /include1.pug

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ var path = require('path');
 var PugDependencies = require('../index.js'),
     baseDir = 'test/fixtures';
 
-var plugin = function(file) {
-    return new PugDependencies(file);
+var plugin = function(file, options) {
+    return new PugDependencies(file, options);
 };
 
 test('Length of dependencies should be 2', function(t) {
@@ -14,6 +14,25 @@ test('Length of dependencies should be 2', function(t) {
     path.join(baseDir, 'extends', 'extends.pug'),
     path.join(baseDir, 'include', 'include1.pug')
   ];
-  t.deepEqual(pugDependencies, expectedResult, 'Array of dependencies with a length of 2 should be returnd.');
+  t.deepEqual(pugDependencies, expectedResult, 'Array of dependencies with a length of 2 should be returned.');
   t.end();
+});
+
+test('Dependencies should have correct path when using basedir option', function(t) {
+  var pugDependencies = plugin('test/fixtures/absolute_include.pug', { basedir: path.join(baseDir, 'include') });
+  var expectedResult = [
+    path.join(baseDir, 'extends', 'extends.pug'),
+    path.join(baseDir, 'include', 'include1.pug')
+  ];
+  t.deepEqual(pugDependencies, expectedResult, 'Dependencies did not have the correct paths.');
+  t.end();
+});
+
+test('Absolute path should throw error when basedir option is not set', function(t) {
+  try {
+    plugin('test/fixtures/absolute_include.pug');
+  } catch (err) {
+    t.deepEqual(err.message, 'the "basedir" option is required to use includes and extends with "absolute" paths');
+    t.end();
+  }
 });


### PR DESCRIPTION
This correctly handles absolute includes and mimics Pugs behaviour. It throws the same error as Pug when receiving an absolute path and basedir is not set.